### PR TITLE
Update index.html

### DIFF
--- a/templates/stripe_charge_succeeded_2015/index.html
+++ b/templates/stripe_charge_succeeded_2015/index.html
@@ -11,7 +11,7 @@
   <li><a href="https://donate.mozilla.org/jan-thank-you-cute">Cute thank you</a></li>
   </ul></p>
 
-  <p>Thanks again, and if you're not currently receiving emails from us, please do <a href="https://www.mozilla.org/newsletter">subscribe here.</p>
+  <p>Thanks again, and if you're not currently receiving emails from us, please do <a href="https://www.mozilla.org/newsletter">subscribe here.</a></p>
 
   <p>Sincerely, </p>
 


### PR DESCRIPTION
added a missing </a> tag after the newsletter signup link over to https://www.mozilla.org/newsletter (right under the links to the three videos).