### PR TITLE
MozFest 2018 proposal confirmation email

### DIFF
--- a/locale/en_US/mozfest_session_proposal_2018.json
+++ b/locale/en_US/mozfest_session_proposal_2018.json
@@ -1,0 +1,12 @@
+{
+  "email_subject": "Your MozFest session proposal",
+  "hi": "Hi {{first_name}},",
+  "thank_you": "Thank you for submitting a session proposal for MozFest!",
+  "session_curation_process": "All proposals will be reviewed and curated on GitHub in the <a href=\"{{ github_program_repo_url }}\">MozFest 2018 program repo</a>. Curation will begin in August when the Call for Proposals closes. In early September, you’ll be notified whether your session has been accepted or not.",
+  "your_session": "Your session is documented in this issue: <a href=\"{{ github_issue_url }}\">{{ github_issue_title }}</a>",
+  "follow_curation": "We encourage you to follow the curation process on GitHub. You can chat with Space Wranglers (the people who curate sessions for each MozFest space), ask questions and share additional information in the comments section of your issue.",
+  "github_video": "If you're new to GitHub, this 45 second <a href=\"https://egghead.io/lessons/javascript-introduction-to-github\">video</a> will walk you through signing up for a free account.",
+  "reach_out": "Questions? Please reach out to <a href=\"mailto:festival@mozilla.org\">festival@mozilla.org</a>",
+  "best_from_team": "Best,<br />The MozFest Team",
+  "ps": "PS - MozFest curation takes place in the open. This means some information, like your name and details about your proposed session, are visible in <a href=\"{{ github_issue_url }}\">your GitHub ticket</a>. If you would like this information removed for privacy reasons, please let us know at <a href=\"mailto:festival@mozilla.org\">festival@mozilla.org</a>"
+}

--- a/templates/mozfest_session_proposal_2018/index.html
+++ b/templates/mozfest_session_proposal_2018/index.html
@@ -1,0 +1,19 @@
+<body>
+  <p>{{ 'hi' | gettext | instantiate | safe }}</p>
+
+  <p>{{ 'thank_you' | gettext | instantiate | safe }}</p>
+
+  <p>{{ 'session_curation_process' | gettext | instantiate | safe }}</p>
+
+  <p>{{ 'your_session' | gettext | instantiate | safe }}</p>
+
+  <p>{{ 'follow_curation' | gettext | instantiate | safe }}</p>
+
+  <p>{{ 'github_video' | gettext | instantiate | safe }}</p>
+
+  <p>{{ 'reach_out' | gettext | instantiate | safe }}</p>
+
+  <p>{{ 'best_from_team' | gettext | instantiate | safe }}</p>
+
+  <p>{{ 'ps' | gettext | instantiate | safe }}</p>
+</body>

--- a/templates/mozfest_session_proposal_2018/index.js
+++ b/templates/mozfest_session_proposal_2018/index.js
@@ -1,0 +1,24 @@
+module.exports = {
+  // Choose a human-readable name. This is just for rendering example pages.
+  name: '2018 Mozilla Festival Session Proposal',
+
+  // Choose a good description; when is this email sent?
+  description: 'When someone submits a session proposal on the Mozilla Festival website',
+
+  // Choose a subject for your email
+  subject: 'email_subject',
+
+  // Create a test case for every possible version of the email,
+  // E.g. with a user name, without a username
+  tests: [
+    {
+      description: 'Chris submits a proposal',
+      data: {
+        first_name: 'Chris',
+        github_program_repo_url: "https://github.com/MozillaFestival/mozfest-program-2018",
+        github_issue_url: "https://github.com/MozillaFestival/mozfest-program-2018/issues/1",
+        github_issue_title: "How to Devops like a Boss"
+      }
+    }
+  ]
+};


### PR DESCRIPTION
Final copy can be found [here](https://github.com/mozilla/mozillafestival.org/issues/858#issuecomment-392202495).

Note that we are only offering email in English this year.